### PR TITLE
fix typo

### DIFF
--- a/docs/go-storage/internal/integration-tests.md
+++ b/docs/go-storage/internal/integration-tests.md
@@ -157,4 +157,4 @@ jobs:
 
 Secrets should be set by the project maintainer, please contact them in the public matrix rooms.
 
-[go-integration-test]: https://github.com/beyondstorage/go-integration-tes
+[go-integration-test]: https://github.com/beyondstorage/go-integration-test


### PR DESCRIPTION
Fix the wrong redirect link which misses the t letter in the end